### PR TITLE
[Feature] Command Buffer Optimization - Ignore previous write command

### DIFF
--- a/TeamProject_SSD/ssd.cpp
+++ b/TeamProject_SSD/ssd.cpp
@@ -81,13 +81,28 @@ bool SSD::IsLBAWritten(const unsigned int& nLBA, unordered_map<unsigned int, uns
 	return umDataSet.find(nLBA) != umDataSet.end();
 }
 
-void SSD::AddCommandToBuffer(int nCmdType, int nLBA, unsigned int nData)
+void SSD::AddCommandToBuffer(int nCmdType, unsigned int nLBA, unsigned int nData)
 {
 	CMD_BUFFER_MAP nCmdBuffer;
 
 	ssdFileHandler.LoadCommandBufferFile(nCmdBuffer);
 
+	if (nCmdType == W)
+	{
+		OptimizeWriteCommand(nCmdBuffer, nLBA);
+	}
+
 	nCmdBuffer[{ nCmdType, nLBA }] = nData;
 
 	ssdFileHandler.WriteCommandBufferFile(nCmdBuffer);
+}
+
+void SSD::OptimizeWriteCommand(CMD_BUFFER_MAP& nCmdBuffer, unsigned int& nLBA)
+{
+	RemovePrevWriteCmdWithSameLBA(nCmdBuffer, nLBA);
+}
+
+void SSD::RemovePrevWriteCmdWithSameLBA(CMD_BUFFER_MAP& nCmdBuffer, unsigned int& nLBA)
+{
+	nCmdBuffer.erase({ W, nLBA });
 }

--- a/TeamProject_SSD/ssd.h
+++ b/TeamProject_SSD/ssd.h
@@ -14,7 +14,10 @@ public:
 private:
 	void ValidateParameter(unsigned int nLBA, unsigned int nSize = 0);
 	bool IsLBAWritten(const unsigned int& nLBA, unordered_map<unsigned int, unsigned int>& umDataSet);
-	void AddCommandToBuffer(int nCmdType, int nLBA, unsigned int nData);
+
+	void AddCommandToBuffer(int nCmdType, unsigned int nLBA, unsigned int nData);
+	void OptimizeWriteCommand(CMD_BUFFER_MAP& nCmdBuffer, unsigned int& nLBA);
+	void RemovePrevWriteCmdWithSameLBA(CMD_BUFFER_MAP& nCmdBuffer, unsigned int& nLBA);
 
 	SSDFileHandler ssdFileHandler;
 	const unsigned int SSD_MAX_LBA = 99;


### PR DESCRIPTION
### Changes
Write Command 처리 시 buffer에 동일 LBA에 대한 Write가 있을 경우 제거하는 command buffer optimization 로직 추가하였습니다.